### PR TITLE
Hotfix pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,7 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
-    args:
-      - '--line-length=79'
+        args: [--line-length=79]
   - repo: 'https://github.com/pre-commit/pre-commit-hooks'
     rev: v3.2.0
     hooks:
@@ -24,8 +23,8 @@ repos:
     rev: v1.7.0
     hooks:
       - id: blacken-docs
-    additional_dependencies:
-      - black==19.3b0
+        additional_dependencies:
+          - black==19.3b0
   - repo: 'https://github.com/asottile/setup-cfg-fmt'
     rev: v1.11.0
     hooks:
@@ -42,10 +41,10 @@ repos:
     rev: v1.24.2
     hooks:
       - id: yamllint
-    args:
-      - '--format'
-      - parsable
-      - '--strict'
+        args:
+          - '--format'
+          - parsable
+          - '--strict'
   - repo: 'https://github.com/Lucas-C/pre-commit-hooks-lxml'
     rev: v1.1.0
     hooks:

--- a/programs/digital_clock.py
+++ b/programs/digital_clock.py
@@ -36,7 +36,10 @@ def label_config(root):
         colors of root.
     """
     clock_label = Label(
-        root, font=("Calibri", 40, "bold"), background="#186C8F", foreground="#F3A548"
+        root,
+        font=("Calibri", 40, "bold"),
+        background="#186C8F",
+        foreground="#F3A548",
     )
     clock_label.pack(anchor="center")
 


### PR DESCRIPTION
.pre-commit-config.yaml:
  - Incorrect indentations was causing black and other hooks to not
    have the args necessary to function.